### PR TITLE
Remove Contact icon in iframe mode

### DIFF
--- a/src/components/layout/Footer.js
+++ b/src/components/layout/Footer.js
@@ -7,7 +7,6 @@ import ContactPrompt from 'components/base/ContactPrompt'
 import Button from 'components/base/Button'
 import Marianne from 'components/base/Marianne'
 import Ademe from 'components/base/Ademe'
-import Logo from 'components/base/Logo'
 import MobileButtons from './footer/MobileButtons'
 
 const Wrapper = styled.footer`

--- a/src/components/layout/Web.js
+++ b/src/components/layout/Web.js
@@ -72,7 +72,7 @@ export default function Web(props) {
               </Content>
               <EmbedWrapper result={props.result} />
               <ShareWrapper result={props.result} />
-              <ContactWrapper />
+              {!iframe && (<ContactWrapper />)}
               <InstallButton />
               <ModalWrapper />
             </ModalProvider>

--- a/src/components/layout/footer/MobileButtons.js
+++ b/src/components/layout/footer/MobileButtons.js
@@ -131,19 +131,21 @@ export default function MobileButtons(props) {
             <Label>Installer</Label>
           </Button>
         )}
-        <Button onClick={() => setContactOpen(true)}>
-          <Icon>
-            <Mail x='0px' y='0px' viewBox='0 0 512 512'>
-              <path
-                d='M467,61H45C20.218,61,0,81.196,0,106v300c0,24.72,20.128,45,45,45h422c24.72,0,45-20.128,45-45V106
-			C512,81.28,491.872,61,467,61z M460.786,91L256.954,294.833L51.359,91H460.786z M30,399.788V112.069l144.479,143.24L30,399.788z
-			 M51.213,421l144.57-144.57l50.657,50.222c5.864,5.814,15.327,5.795,21.167-0.046L317,277.213L460.787,421H51.213z M482,399.787
-			L338.213,256L482,112.212V399.787z'
-              />
-            </Mail>
-          </Icon>
-          <Label>Contact</Label>
-        </Button>
+        {!props.iframe && (
+          <Button onClick={() => setContactOpen(true)}>
+            <Icon>
+              <Mail x='0px' y='0px' viewBox='0 0 512 512'>
+                <path
+                  d='M467,61H45C20.218,61,0,81.196,0,106v300c0,24.72,20.128,45,45,45h422c24.72,0,45-20.128,45-45V106
+        C512,81.28,491.872,61,467,61z M460.786,91L256.954,294.833L51.359,91H460.786z M30,399.788V112.069l144.479,143.24L30,399.788z
+        M51.213,421l144.57-144.57l50.657,50.222c5.864,5.814,15.327,5.795,21.167-0.046L317,277.213L460.787,421H51.213z M482,399.787
+        L338.213,256L482,112.212V399.787z'
+                />
+              </Mail>
+            </Icon>
+            <Label>Contact</Label>
+          </Button>
+        )}
         {props.iframe && (
           <StyledLink to={process.env.GATSBY_URL || 'https://ademe.fr'}>
             <Icon>
@@ -162,7 +164,9 @@ export default function MobileButtons(props) {
       </Wrapper>
       <EmbedWrapper small />
       <ShareWrapper small />
-      <ContactWrapper small />
-    </>
+      {!props.iframe && (
+        <ContactWrapper small />
+      )}
+      </>
   )
 }


### PR DESCRIPTION
It brings to much noise for support team. We prefer keep the contact us option only for standalone solution

IFrame mode:

![CleanShot 2023-12-21 at 11 35 39](https://github.com/incubateur-ademe/quefairedemesdechets/assets/454431/f4d7c70d-e8d9-4772-b489-91b9e33f591f)

Standalone mode:
![CleanShot 2023-12-21 at 11 38 17](https://github.com/incubateur-ademe/quefairedemesdechets/assets/454431/e3c77975-f3b2-405d-be54-594516cc9fb0)

Same in mobile size screen in the footer, the contact icon is hidden