### PR TITLE
Remove HouseNumber option when call api-adresse service

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -85,7 +85,7 @@ export function useSearch(search) {
       search && search.length > 2
         ? axios
             .get(
-              `https://api-adresse.data.gouv.fr/search/?q=${search}&type=housenumber`
+              `https://api-adresse.data.gouv.fr/search/?q=${search}`
             )
             .then((res) => res.data.features)
         : Promise.resolve([]),


### PR DESCRIPTION
You won't have to set number in the street to search your place

![CleanShot 2024-01-18 at 16 40 57](https://github.com/incubateur-ademe/quefairedemesdechets/assets/454431/b01d87c9-2ab1-4ea5-9392-a472fd8f522e)
