### PR TITLE
Suppression de warning dans la console navigateur 

### DIFF
--- a/src/components/base/Accordion.tsx
+++ b/src/components/base/Accordion.tsx
@@ -18,7 +18,7 @@ const Title = styled.button<{ $expanded?: boolean }>`
   jutify-content: space-between;
   padding: 1rem;
   cursor: pointer;
-  transition: .25s; 
+  transition: .25s;
   user-select: none;
   -webkit-user-select: none;
   -webkit-appearance: button;
@@ -50,7 +50,7 @@ const AccordionItemWrapper = styled.div`
 `
 
 
-const Content = styled.p<{ $expanded?: boolean; }> `
+const Content = styled.div<{ $expanded?: boolean; }> `
   display: none;
   padding: 1rem;
   ${({ $expanded }) => $expanded && `display: block;`}

--- a/src/components/base/Button.js
+++ b/src/components/base/Button.js
@@ -8,7 +8,7 @@ const Wrapper = styled(MagicLink)`
   justify-content: center;
   align-items: center;
   padding: 0.8em 1.6em;
-  font-size: ${(props) => (props.small ? "0.875em" : "1em")};
+  font-size: ${(props) => (props.$small ? "0.875em" : "1em")};
   text-align: center;
   text-decoration: none;
   color: ${(props) =>
@@ -49,8 +49,8 @@ export default function Button(props) {
       to={props.to}
       onClick={props.onClick}
       disabled={props.disabled}
-      hollow={props.hollow}
-      small={props.small}
+      $hollow={props.hollow}
+      $small={props.small}
       className={props.className}
       textColor={props.textColor}
       aria-label={props.children}

--- a/src/components/base/Checkbox.js
+++ b/src/components/base/Checkbox.js
@@ -4,7 +4,7 @@ import styled from "styled-components";
 const Wrapper = styled.div`
   position: relative;
   display: inline-block;
-  font-size: ${(props) => (props.small ? "1em" : "1.2em")};
+  font-size: ${(props) => (props.$small ? "1em" : "1.2em")};
 
   &:before {
     content: "";
@@ -51,7 +51,7 @@ export default function Checkbox(props) {
   return (
     <Wrapper
       checked={props.checked}
-      small={props.small}
+      $small={props.small}
       className={props.className}
     >
       <Input

--- a/src/components/base/Modal.js
+++ b/src/components/base/Modal.js
@@ -12,7 +12,7 @@ const Wrapper = styled.div`
   justify-content: center;
   align-items: center;
   transform: translate3d(0, 0, 1em);
-  pointer-events: ${(props) => (props.open ? "inherit" : "none")};
+  pointer-events: ${(props) => (props.$open ? "inherit" : "none")};
 `;
 const Background = styled.div`
   position: absolute;
@@ -20,27 +20,27 @@ const Background = styled.div`
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, ${(props) => (props.open ? 0.6 : 0)});
-  transition: background-color ${(props) => (props.open ? "300ms" : "1ms")}
+  background-color: rgba(0, 0, 0, ${(props) => (props.$open ? 0.6 : 0)});
+  transition: background-color ${(props) => (props.$open ? "300ms" : "1ms")}
     ease-in-out;
 `;
 const Content = styled.div`
   position: relative;
   display: flex;
   flex-direction: column;
-  width: ${(props) => props.width || "30em"};
+  width: ${(props) => props.$width || "30em"};
   max-width: 90vw;
   max-height: 90vh;
   margin: 1rem;
   background-color: ${(props) => props.theme.colors.background};
   border-radius: 1em;
   box-shadow: 0px 0px 15px 10px rgba(0, 0, 0, 0.2);
-  visibility: ${(props) => (props.open ? "visible" : "hidden")};
-  opacity: ${(props) => (props.open ? 1 : 0)};
-  transform: scale(${(props) => (props.open ? 1 : 0.7)})
-    translateY(${(props) => (props.open ? 0 : "10em")});
+  visibility: ${(props) => (props.$open ? "visible" : "hidden")};
+  opacity: ${(props) => (props.$open ? 1 : 0)};
+  transform: scale(${(props) => (props.$open ? 1 : 0.7)})
+    translateY(${(props) => (props.$open ? 0 : "10em")});
   transition: all
-    ${(props) => (props.open && !props.noAnimation ? "300ms" : "1ms")}
+    ${(props) => (props.$open && !props.$noAnimation ? "300ms" : "1ms")}
     ease-in-out;
 `;
 const ButtonClose = styled.div`
@@ -60,14 +60,14 @@ const Scroll = styled.div`
 `;
 export default function Modal(props) {
   return (
-    <Wrapper open={props.open} className={props.className}>
-      <Background open={props.open} onClick={() => props.setOpen(false)} />
+    <Wrapper $open={props.open} className={props.className}>
+      <Background $open={props.open} onClick={() => props.setOpen(false)} />
       <Content
-        open={props.open}
+        $open={props.open}
         width={props.width}
         textColor={props.textColor}
-        backgroundColor={props.backgroundColor}
-        noAnimation={props.noAnimation}
+        $backgroundColor={props.backgroundColor}
+        $noAnimation={props.noAnimation}
       >
         <ButtonClose onClick={() => props.setOpen(false)}>+</ButtonClose>
         <Scroll>{props.children}</Scroll>

--- a/src/components/base/Panel.js
+++ b/src/components/base/Panel.js
@@ -8,11 +8,11 @@ import ContactButton from "./panel/ContactButton";
 
 const Wrapper = styled.div`
   position: relative;
-  width: ${(props) => (props.open ? "30rem" : 0)};
+  width: ${(props) => (props.$open ? "30rem" : 0)};
   transition: width 400ms ease-out;
 
   ${(props) => props.theme.mq.medium} {
-    display: ${(props) => (props.open && props.small ? "block" : "none")};
+    display: ${(props) => (props.$open && props.$small ? "block" : "none")};
     width: auto;
     border-left: none;
     transition: none;
@@ -27,11 +27,11 @@ const Content = styled.div`
   height: 100%;
   padding: 2rem;
   background-color: ${(props) =>
-    props.small ? "transparent" : props.theme.colors.background};
+    props.$small ? "transparent" : props.theme.colors.background};
   border-left: 5px solid ${(props) => props.theme.colors.main};
   overflow-y: auto;
   overflow-x: visible;
-  transform: translateX(${(props) => (props.open ? 0 : "100%")});
+  transform: translateX(${(props) => (props.$open ? 0 : "100%")});
   transition: transform 400ms ease-out;
 
   ${(props) => props.theme.mq.medium} {
@@ -68,7 +68,7 @@ const ButtonClose = styled.div`
 export default function Panel(props) {
   const { width } = useWindowSize();
   return (width > 1200 && !props.small) || (width <= 1200 && props.small) ? (
-    <Wrapper open={props.open} small={props.small} id={props.id}>
+    <Wrapper $open={props.open} $small={props.small} id={props.id}>
       {!props.small &&
         (props.index === 0 ? (
           <EmbedButton
@@ -89,7 +89,7 @@ export default function Panel(props) {
             index={props.index}
           />
         ))}
-      <Content open={props.open} small={props.small}>
+      <Content $open={props.open} $small={props.small}>
         <ButtonClose onClick={props.toggleClose}>+</ButtonClose>
         {props.children}
       </Content>

--- a/src/components/base/TextArea.js
+++ b/src/components/base/TextArea.js
@@ -8,7 +8,7 @@ const Label = styled.label`
   display: block;
   margin-bottom: 0.5rem;
   font-weight: bold;
-  color: ${(props) => props.theme.colors[props.error ? "error" : "text"]};
+  color: ${(props) => props.theme.colors[props.$error ? "error" : "text"]};
 `;
 const Input = styled.textarea`
   width: 100%;
@@ -30,7 +30,7 @@ export default function TextArea(props) {
   return (
     <Wrapper>
       {props.label && (
-        <Label htmlFor={props.name} error={props.error}>
+        <Label htmlFor={props.name} $error={props.error}>
           {props.label}
         </Label>
       )}
@@ -39,7 +39,7 @@ export default function TextArea(props) {
         id={props.name}
         name={props.name}
         value={props.value}
-        error={props.error}
+        $error={props.error}
         onChange={(e) => {
           props.onChange({ value: e.currentTarget.value, name: props.name });
         }}

--- a/src/components/base/TextInput.js
+++ b/src/components/base/TextInput.js
@@ -8,7 +8,7 @@ const Label = styled.label`
   display: block;
   margin-bottom: 0.5rem;
   font-weight: bold;
-  color: ${(props) => props.theme.colors[props.error ? "error" : "text"]};
+  color: ${(props) => props.theme.colors[props.$error ? "error" : "text"]};
 `;
 const Input = styled.input`
   width: 100%;
@@ -16,7 +16,7 @@ const Input = styled.input`
   color: ${(props) => props.theme.colors.text};
   background-color: transparent;
   border: 2px solid
-    ${(props) => props.theme.colors[props.error ? "error" : "second"]};
+    ${(props) => props.theme.colors[props.$error ? "error" : "second"]};
   border-radius: 1rem;
   transition: box-shadow 300ms ease-out;
 
@@ -29,7 +29,7 @@ export default function TextInput(props) {
   return (
     <Wrapper>
       {props.label && (
-        <Label htmlFor={props.name} error={props.error}>
+        <Label htmlFor={props.name} $error={props.error}>
           {props.label}
         </Label>
       )}
@@ -38,7 +38,7 @@ export default function TextInput(props) {
         id={props.name}
         name={props.name}
         value={props.value}
-        error={props.error}
+        $error={props.error}
         onChange={(e) => {
           props.onChange({ value: e.currentTarget.value, name: props.name });
         }}

--- a/src/components/base/ThemeToggle.js
+++ b/src/components/base/ThemeToggle.js
@@ -15,7 +15,7 @@ const Wrapper = styled.div`
     position: relative;
     left: 0;
     right: 0;
-    display: ${(props) => (props.mobile ? "block" : "none")};
+    display: ${(props) => (props.$mobile ? "block" : "none")};
     text-align: center;
   }
 `;
@@ -32,7 +32,7 @@ export default function Visible(props) {
   const { theme, setTheme } = useContext(StyleContext);
 
   return (
-    <Wrapper mobile={props.mobile}>
+    <Wrapper $mobile={props.mobile}>
       <Switch
         onChange={() =>
           setTheme((prevTheme) =>

--- a/src/components/base/panel/EmbedButton.js
+++ b/src/components/base/panel/EmbedButton.js
@@ -20,8 +20,8 @@ const hover = keyframes`
 `;
 const StyledWrapper = styled(Toggle)`
   transform: translate(
-    ${(props) => (props.open ? "-30rem" : "0")},
-    calc(${(props) => (props.four ? "-200% - 3rem" : "-150% - 2rem")})
+    ${(props) => (props.$open ? "-30rem" : "0")},
+    calc(${(props) => (props.$four ? "-200% - 3rem" : "-150% - 2rem")})
   );
 
   &:hover,
@@ -39,7 +39,7 @@ const Embed = styled.svg`
   display: block;
   width: 2.75rem;
   height: auto;
-  opacity: ${(props) => (props.open ? 0 : 1)};
+  opacity: ${(props) => (props.$open ? 0 : 1)};
   transition: all 300ms ease-out;
 
   path {
@@ -51,13 +51,13 @@ export default function EmbedButton(props) {
 
   return (
     <StyledWrapper
-      open={props.open}
+      $open={props.open}
       onClick={props.onClick}
-      four={installPrompt}
+      $four={installPrompt}
       tooltip={"Intégrer ce simulateur"}
     >
       <Embed
-        open={props.open}
+        $open={props.open}
         x="0px"
         y="0px"
         width="94.504px"

--- a/src/components/base/panel/ShareButton.js
+++ b/src/components/base/panel/ShareButton.js
@@ -17,8 +17,8 @@ const hover = keyframes`
 `;
 const StyledWrapper = styled(Toggle)`
   transform: translate(
-    ${(props) => (props.open ? "-30rem" : "0")},
-    ${(props) => (props.four ? "calc(-100% - 1rem)" : "-50%")}
+    ${(props) => (props.$open ? "-30rem" : "0")},
+    ${(props) => (props.$four ? "calc(-100% - 1rem)" : "-50%")}
   );
 
   &:hover,
@@ -37,7 +37,7 @@ const Share = styled.svg`
   display: block;
   width: 2.25rem;
   height: auto;
-  opacity: ${(props) => (props.open ? 0 : 1)};
+  opacity: ${(props) => (props.$open ? 0 : 1)};
   transition: all 300ms ease-out;
 
   path {
@@ -56,13 +56,13 @@ export default function ShareButton(props) {
 
   return (
     <StyledWrapper
-      open={props.open}
+      $open={props.open}
       onClick={props.onClick}
-      four={installPrompt}
+      $four={installPrompt}
       tooltip={"Partager ce simulateur"}
     >
       <Share
-        open={props.open}
+        $open={props.open}
         height="512pt"
         viewBox="-21 0 512 512"
         width="512pt"

--- a/src/components/base/panel/Toggle.js
+++ b/src/components/base/panel/Toggle.js
@@ -40,7 +40,7 @@ export default function Toggle(props) {
     <>
       <Wrapper
         className={props.className}
-        open={props.open}
+        $open={props.$open}
         onClick={props.onClick}
         data-tip={props.tooltip}
         aria-label={props.tooltip}

--- a/src/components/layout/Contact.js
+++ b/src/components/layout/Contact.js
@@ -106,7 +106,7 @@ export default function Contact(props) {
             <TextInput
               name={"nom"}
               value={user.nom}
-              error={empty && !user.nom}
+              $error={empty && !user.nom}
               label={"Votre nom"}
               onChange={({ name, value }) =>
                 setUser((prevUser) => ({ ...prevUser, [name]: value }))
@@ -117,7 +117,7 @@ export default function Contact(props) {
             <TextInput
               type="email"
               name={"email"}
-              error={empty && !user.email}
+              $error={empty && !user.email}
               value={user.email}
               label={"Votre email"}
               onChange={({ name, value }) =>
@@ -160,7 +160,7 @@ export default function Contact(props) {
             <TextArea
               name={"message"}
               value={user.message}
-              error={empty && !user.message}
+              $error={empty && !user.message}
               label={"Votre message"}
               onChange={({ name, value }) =>
                 setUser((prevUser) => ({ ...prevUser, [name]: value }))

--- a/src/components/layout/Web.js
+++ b/src/components/layout/Web.js
@@ -37,7 +37,7 @@ const FullScreen = styled.div`
   flex-direction: column;
   width: 67rem;
   max-width: 100%;
-  min-height: ${(props) => (props.iframe ? "none" : "100vh")};
+  min-height: ${(props) => (props.$iframe ? "none" : "100vh")};
   margin: 0 auto;
   padding: 0 0.75rem 5rem;
 `;
@@ -60,7 +60,7 @@ export default function Web(props) {
             <GlobalStyle />
             <ThemeToggle />
             <Content>
-              <FullScreen iframe={iframe}>
+              <FullScreen $iframe={iframe}>
                 <HeaderWrapper noHeader={noHeader} />
                 {props.children}
                 <Bin />

--- a/src/components/layout/embed/Code.js
+++ b/src/components/layout/embed/Code.js
@@ -25,7 +25,7 @@ const Text = styled.code`
     right: 0;
     font-size: 0.875em;
     color: ${(props) => props.theme.colors.main};
-    opacity: ${(props) => (props.copied ? 1 : 0)};
+    opacity: ${(props) => (props.$copied ? 1 : 0)};
     transition: opacity 300ms ease-out;
   }
 `;
@@ -53,7 +53,7 @@ export default function Code(props) {
   return (
     <Wrapper>
       <Text
-        copied={copied}
+        $copied={copied}
         onClick={() => {
           if (copy(script)) {
             setCopied(true);

--- a/src/components/layout/embed/themes/Theme.js
+++ b/src/components/layout/embed/themes/Theme.js
@@ -9,11 +9,11 @@ const Content = styled.div`
   width: 100%;
   height: 100%;
   padding: 1rem;
-  font-family: ${(props) => props.displayTheme.fonts};
-  background-color: ${(props) => props.displayTheme.colors.background};
+  font-family: ${(props) => props.$displayTheme.fonts};
+  background-color: ${(props) => props.$displayTheme.colors.background};
   border: 0.125rem solid
     ${(props) =>
-      props.displayTheme.colors[props.current ? "main" : "background"]};
+      props.$displayTheme.colors[props.$current ? "main" : "background"]};
   border-radius: 1rem;
   cursor: pointer;
 `;
@@ -21,7 +21,7 @@ const Title = styled.div`
   margin-bottom: 0.4em;
   font-size: 1.5em;
   font-weight: bold;
-  color: ${(props) => props.displayTheme.colors.second};
+  color: ${(props) => props.$displayTheme.colors.second};
 `;
 const Tiles = styled.div`
   display: flex;
@@ -32,14 +32,14 @@ const Tile = styled.div`
   height: 2em;
   margin: 0 0.5em;
   background-color: ${(props) =>
-    props.active
-      ? props.displayTheme.colors.main
-      : props.displayTheme.colors.background};
+    props.$active
+      ? props.$displayTheme.colors.main
+      : props.$displayTheme.colors.background};
   border: 2px solid
     ${(props) =>
-      props.active
-        ? props.displayTheme.colors.main
-        : props.displayTheme.colors.text};
+      props.$active
+        ? props.$displayTheme.colors.main
+        : props.$displayTheme.colors.text};
   border-radius: 0.5em;
 `;
 export default function Theme(props) {
@@ -47,14 +47,14 @@ export default function Theme(props) {
     <Wrapper>
       <Content
         onClick={props.onClick}
-        current={props.current}
-        displayTheme={props.theme}
+        $current={props.current}
+        $displayTheme={props.theme}
       >
-        <Title displayTheme={props.theme}>{props.theme.name}</Title>
+        <Title $displayTheme={props.theme}>{props.theme.name}</Title>
         <Tiles>
-          <Tile displayTheme={props.theme} />
-          <Tile displayTheme={props.theme} />
-          <Tile active displayTheme={props.theme} />
+          <Tile $displayTheme={props.theme} />
+          <Tile $displayTheme={props.theme} />
+          <Tile $active $displayTheme={props.theme} />
         </Tiles>
       </Content>
     </Wrapper>

--- a/src/components/layout/footer/MobileButtons.js
+++ b/src/components/layout/footer/MobileButtons.js
@@ -10,7 +10,7 @@ import MagicLink from "components/base/MagicLink";
 const Wrapper = styled.div`
   display: none;
   justify-content: space-around;
-  margin-bottom: ${(props) => (props.iframe ? 1 : 2)}rem;
+  margin-bottom: ${(props) => (props.$iframe ? 1 : 2)}rem;
 
   ${(props) => props.theme.mq.medium} {
     display: flex;
@@ -77,7 +77,7 @@ export default function MobileButtons(props) {
     useContext(UXContext);
   return (
     <>
-      <Wrapper iframe={props.iframe}>
+      <Wrapper $iframe={props.iframe}>
         <Button onClick={() => setEmbedOpen(true)}>
           <Icon>
             <Embed

--- a/src/components/layout/share/Link.js
+++ b/src/components/layout/share/Link.js
@@ -52,7 +52,7 @@ const Check = styled.svg`
   width: 1rem;
   height: auto;
   vertical-align: top;
-  opacity: ${(props) => (props.copied ? 1 : 0)};
+  opacity: ${(props) => (props.$copied ? 1 : 0)};
   transition: opacity 200ms ease-out;
   path {
     fill: ${(props) => props.theme.colors.background};
@@ -87,7 +87,7 @@ export default function Code(props) {
       >
         Copier{" "}
         <Check
-          copied={copied}
+          $copied={copied}
           height="417pt"
           viewBox="0 -46 417.81333 417"
           width="417pt"

--- a/src/components/misc/Bin.js
+++ b/src/components/misc/Bin.js
@@ -193,7 +193,7 @@ export default function Bin() {
   const [visible, setVisible] = useState(true);
 
   return (
-    <Position position={positions[currentPosition]}>
+    <Position $position={positions[currentPosition]}>
       <Wrapper
         $visible={visible && isSuccess}
         $flight={binFlight}
@@ -211,7 +211,7 @@ export default function Bin() {
       >
         <Svg
           aria-hidden="true"
-          visible={visible}
+          $visible={visible}
           width="133"
           height="133"
           viewBox="0 0 133 133"

--- a/src/components/misc/Bin.js
+++ b/src/components/misc/Bin.js
@@ -120,13 +120,13 @@ const hover = keyframes`
 const Position = styled.div`
   position: fixed;
   z-index: 12;
-  ${(props) => props.position["y"]}: 0;
-  ${(props) => props.position["x"]}: 1rem;
-  transform: rotate(${(props) => (props.position["y"] === "top" ? 180 : 0)}deg)
+  ${(props) => props.$position["y"]}: 0;
+  ${(props) => props.$position["x"]}: 1rem;
+  transform: rotate(${(props) => (props.$position["y"] === "top" ? 180 : 0)}deg)
     translateX(
       ${(props) =>
-        (props.position["y"] === "bottom" && props.position["x"] === "right") ||
-        (props.position["y"] === "top" && props.position["x"] === "left")
+        (props.$position["y"] === "bottom" && props.$position["x"] === "right") ||
+        (props.$position["y"] === "top" && props.$position["x"] === "left")
           ? -8.3125
           : 0}rem
     );
@@ -134,16 +134,16 @@ const Position = styled.div`
 const Wrapper = styled.div`
   position: absolute;
   cursor: pointer;
-  transform: translateY(${(props) => (props.visible ? -50 : 0)}%);
+  transform: translateY(${(props) => (props.$visible ? -50 : 0)}%);
   transition: transform 400ms ease-out
-    ${(props) => (props.visible ? "1000ms" : "0ms")};
+    ${(props) => (props.$visible ? "1000ms" : "0ms")};
   animation: ${(props) =>
-      props.flight
-        ? props.position["x"] === "left"
-          ? props.position["y"] === "bottom"
+      props.$flight
+        ? props.$position["x"] === "left"
+          ? props.$position["y"] === "bottom"
             ? flightLeft
             : flightRight
-          : props.position["y"] === "bottom"
+          : props.$position["y"] === "bottom"
             ? flightRight
             : flightLeft
         : ""}
@@ -160,7 +160,7 @@ const Svg = styled.svg`
   }
 
   &:hover {
-    animation: ${(props) => (props.visible ? hover : "")} 500ms infinite;
+    animation: ${(props) => (props.$visible ? hover : "")} 500ms infinite;
   }
 `;
 const Eye = styled.circle`
@@ -195,9 +195,9 @@ export default function Bin() {
   return (
     <Position position={positions[currentPosition]}>
       <Wrapper
-        visible={visible && isSuccess}
-        flight={binFlight}
-        position={positions[currentPosition]}
+        $visible={visible && isSuccess}
+        $flight={binFlight}
+        $position={positions[currentPosition]}
         onClick={() => {
           setVisible(false);
           setTimeout(() => {

--- a/src/components/misc/GifTitle.js
+++ b/src/components/misc/GifTitle.js
@@ -10,7 +10,7 @@ const StyledMagicLink = styled(MagicLink)`
 `;
 const Wrapper = styled.h1`
   position: relative;
-  margin-bottom: ${(props) => (props.small ? 0 : 2.5)}rem;
+  margin-bottom: ${(props) => (props.$small ? 0 : 2.5)}rem;
   text-align: center;
 `;
 
@@ -20,7 +20,7 @@ export default function GifTitle(props) {
       to="/"
       title="Que Faire de mes Déchets ? Retour à l’accueil"
     >
-      <Wrapper small={props.small} as="h1">
+      <Wrapper $small={props.small} as="h1">
         <span hidden>Que faire de mes Objets et de mes Déchets</span>
         <img
           src={props.small ? qfdmodSmallGif : qfdmodGif}

--- a/src/components/misc/SearchBar.js
+++ b/src/components/misc/SearchBar.js
@@ -19,7 +19,7 @@ const Wrapper = styled.form`
   border: 0.25em solid ${(props) => props.theme.colors.main};
   border-radius: 2em;
   overflow: hidden;
-  opacity: ${(props) => (props.isFetched && !props.small ? 1 : 0)};
+  opacity: ${(props) => (props.$isFetched && !props.small ? 1 : 0)};
   pointer-events: ${(props) => (props.small ? "none" : "inherit")};
   transition: opacity 750ms;
 
@@ -81,9 +81,9 @@ export default function SearchBar(props) {
 
   return (
     <Wrapper
-      isFetched={props.isFetched}
+      $isFetched={props.isFetched}
       small={props.small}
-      focus={focus}
+      focus={focus.toString()}
       onSubmit={(e) => {
         e.preventDefault();
         if (results[current]) {

--- a/src/components/misc/SearchBar.js
+++ b/src/components/misc/SearchBar.js
@@ -19,7 +19,7 @@ const Wrapper = styled.form`
   border: 0.25em solid ${(props) => props.theme.colors.main};
   border-radius: 2em;
   overflow: hidden;
-  opacity: ${(props) => (props.$isFetched && !props.small ? 1 : 0)};
+  opacity: ${(props) => (props.$isFetched && !props.$small ? 1 : 0)};
   pointer-events: ${(props) => (props.small ? "none" : "inherit")};
   transition: opacity 750ms;
 
@@ -82,7 +82,7 @@ export default function SearchBar(props) {
   return (
     <Wrapper
       $isFetched={props.isFetched}
-      small={props.small}
+      $small={props.small}
       focus={focus.toString()}
       onSubmit={(e) => {
         e.preventDefault();

--- a/src/components/misc/mapWrapper/address/textInput/Geoloc.js
+++ b/src/components/misc/mapWrapper/address/textInput/Geoloc.js
@@ -8,7 +8,7 @@ const fetching = keyframes`
   from {
    opacity: 1;
   }
-  
+
   50% {
    opacity: 0;
   }
@@ -25,16 +25,16 @@ const Wrapper = styled.button`
   background: ${(props) => props.theme.colors.background};
   border: none;
   border-radius: 1.375rem;
-  opacity: ${(props) => (props.visible ? 1 : 0)};
-  pointer-events: ${(props) => (props.visible ? "inherit" : "none")};
-  transition: opacity ${(props) => (props.visible ? 600 : 0)}ms;
-  cursor: ${(props) => (props.fetching ? "wait" : "pointer")};
+  opacity: ${(props) => (props.$visible ? 1 : 0)};
+  pointer-events: ${(props) => (props.$visible ? "inherit" : "none")};
+  transition: opacity ${(props) => (props.$visible ? 600 : 0)}ms;
+  cursor: ${(props) => (props.$fetching ? "wait" : "pointer")};
 
   svg {
     display: block;
     width: 1.375rem;
     height: auto;
-    animation: ${(props) => (props.fetching ? fetching : "")} 1000ms infinite;
+    animation: ${(props) => (props.$fetching ? fetching : "")} 1000ms infinite;
 
     path {
       fill: ${(props) => props.theme.colors.main};
@@ -74,7 +74,7 @@ export default function Geoloc(props) {
 
   useEffect(() => {
     data && data.features && props.navigateToPlace(data.features[0]);
-  }, [data]);
+  }, [data, props]);
 
   const [error, setError] = useState(false);
 
@@ -83,8 +83,8 @@ export default function Geoloc(props) {
     "geolocation" in navigator ? (
     <>
       <Wrapper
-        visible={props.visible && !error && !isError}
-        fetching={isFetching || isGeolocating}
+        $visible={props.visible && !error && !isError}
+        $fetching={isFetching || isGeolocating}
         type="button"
         onClick={() => {
           if (!isFetching && !isGeolocating) setIsGeolocating(true);

--- a/src/components/misc/mapWrapper/address/textInput/Submit.js
+++ b/src/components/misc/mapWrapper/address/textInput/Submit.js
@@ -10,9 +10,9 @@ const Wrapper = styled.button`
   background: ${(props) => props.theme.colors.background};
   border: none;
   border-radius: 1.375rem;
-  opacity: ${(props) => (props.visible ? 1 : 0)};
-  pointer-events: ${(props) => (props.visible ? "inherit" : "none")};
-  transition: opacity ${(props) => (props.visible ? 600 : 0)}ms;
+  opacity: ${(props) => (props.$visible ? 1 : 0)};
+  pointer-events: ${(props) => (props.$visible ? "inherit" : "none")};
+  transition: opacity ${(props) => (props.$visible ? 600 : 0)}ms;
   cursor: pointer;
 
   &:focus {
@@ -32,7 +32,7 @@ const Wrapper = styled.button`
 export default function Submit(props) {
   return (
     <Wrapper
-      visible={props.visible}
+      $visible={props.visible}
       onFocus={() => props.setFocus(true)}
       onBlur={() => props.setFocus(false)}
       aria-label="Valider mon adresse"

--- a/src/components/wrappers/HeaderWrapper.js
+++ b/src/components/wrappers/HeaderWrapper.js
@@ -10,14 +10,14 @@ import SearchBar from "components/misc/SearchBar";
 const StyledHeader = styled(Header)`
   ${(props) => props.theme.mq.small} {
     &:before {
-      content: ${(props) => (props.small ? '""' : "none")};
+      content: ${(props) => (props.$small ? '""' : "none")};
       position: absolute;
       bottom: 0;
       left: -0.75rem;
       right: -0.75rem;
       height: 0.125rem;
       background-color: ${(props) =>
-        props.theme.colors[props.noHeader ? "background" : "second"]};
+        props.theme.colors[props.$noHeader ? "background" : "second"]};
     }
   }
 `;
@@ -29,12 +29,12 @@ const Wrapper = styled.div`
 `;
 const SearchBarWrapper = styled.div`
   position: relative;
-  width: ${(props) => (props.noHeader ? "100%" : "20rem")};
+  width: ${(props) => (props.$noHeader ? "100%" : "20rem")};
   height: 2.875rem;
-  margin-top: ${(props) => (props.noHeader ? "1rem" : 0)};
+  margin-top: ${(props) => (props.$noHeader ? "1rem" : 0)};
 
   ${(props) => props.theme.mq.small} {
-    display: ${(props) => (props.noHeader ? "block" : "none")};
+    display: ${(props) => (props.$noHeader ? "block" : "none")};
   }
 `;
 const StyledSearchBar = styled(SearchBar)`
@@ -49,11 +49,11 @@ export default function HeaderWrapper(props) {
   const location = useLocation();
   const { isFetched } = useWaste();
   return (
-    <StyledHeader small={location.pathname !== "/"} noHeader={props.noHeader}>
+    <StyledHeader $small={location.pathname !== "/"} $noHeader={props.noHeader}>
       {location.pathname !== "/" && (
         <Wrapper>
           {!props.noHeader && <GifTitle small />}
-          <SearchBarWrapper noHeader={props.noHeader}>
+          <SearchBarWrapper $noHeader={props.noHeader}>
             <StyledSearchBar isFetched={isFetched} />
           </SearchBarWrapper>
         </Wrapper>

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,6 +1,6 @@
 /*eslint-disable eqeqeq*/
 
-import { useQuery, useMutation } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import slug from "slug";
 import useDebounce from "hooks/useDebounce";
 

--- a/src/views/home/SuggestionsWrapper.js
+++ b/src/views/home/SuggestionsWrapper.js
@@ -7,7 +7,7 @@ import Suggestions from "components/misc/Suggestions";
 
 const Wrapper = styled.div`
   padding-bottom: 1rem;
-  opacity: ${(props) => (props.isFetched ? 1 : 0)};
+  opacity: ${(props) => (props.$isFetched ? 1 : 0)};
   transition: opacity 1500ms 500ms;
 
   ${(props) => props.theme.mq.small} {
@@ -25,7 +25,7 @@ export default function SuggestionsWrapper() {
   }, [setSearch]);
 
   return (
-    <Wrapper isFetched={isFetched}>
+    <Wrapper $isFetched={isFetched}>
       <Suggestions>
         En panne d’inspiration ? Essayez une des suggestions ci‑dessous.
       </Suggestions>


### PR DESCRIPTION
Durant le développement, certains props utilisés pour `styled-components` sont rendus dans le HTML. 

Cela génère du HTML non valide et peut être contourné en préfixant d'un `$` ces props. 

Ces warning s'affichent comme erreur, et donc en prod, ce qui n'est pas fou fou 