### PR TITLE
add meta for google search console authentication

### DIFF
--- a/src/components/layout/web/Seo.js
+++ b/src/components/layout/web/Seo.js
@@ -38,6 +38,7 @@ const SEO = (props) => {
     <Helmet title={seo.title}>
       <meta name="description" content={seo.description} />
       <meta name="image" content={seo.image} />
+      <meta name="google-site-verification" content="vHhqbYkCiU-dtj5Ona46jyfzS5E0NvNfnROEqtcRAWE" />
 
       {seo.url && <meta property="og:url" content={seo.url} />}
 


### PR DESCRIPTION
Permet d'authentifier le site quefairedemesdechets.ademe.fr dans la google search console sans modifier les DNS. 

Cf https://www.notion.so/accelerateur-transition-ecologique-ademe/Param-trer-search-console-de-Google-pour-avoir-les-mots-cl-s-sur-les-moteurs-de-recherche-6e22b0e6ae264d149ffa9963d63ad1e9?pvs=4 