### PR TITLE
Send referrer to LVAO iframe 

### DIFF
--- a/src/views/product/details/Map.js
+++ b/src/views/product/details/Map.js
@@ -32,6 +32,7 @@ const IFrameWrapper = ({ src }) => {
       mozallowfullscreen="true"
       ref={iframeRef}
       onLoad={handleLoad}
+      referrerPolicy="strict-origin-when-cross-origin"
       src={src}
     />
   );


### PR DESCRIPTION
Le header `Referrer-policy` définit la manière dont va être communiquée l'URL courante aux éventuelles iframe. 
  
Par défaut il est défini à `same-origin` sur Netlify, ce qui nous empêche d'avoir ces infos côté posthog LVAO. 
  
On peut le supplanter via l'attribut `referrerpolicy`, c'est testé et ça fonctionne comme on le souhaite. 

> [strict-origin-when-cross-origin](https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/referrerPolicy#strict-origin-when-cross-origin) (default)
> This is the user agent's default behavior if no policy is specified. Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP).
> 

  
Cf : 
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/referrerPolicy


On a bien la preview qui remonte dans posthog 

<img width="1239" alt="image" src="https://github.com/user-attachments/assets/05f75f2b-a607-4fe0-a1d6-6a3f3abd4347">
