### PR TITLE
Mise en place du tracking cookieless pour Matomo et Posthog

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -1,16 +1,16 @@
-import dotenv from 'dotenv';
+import dotenv from "dotenv";
 dotenv.config({ path: `.env` });
 
-import type { GatsbyConfig } from 'gatsby';
+import type { GatsbyConfig } from "gatsby";
 
 const config: GatsbyConfig = {
   headers: [
     {
-      source: '*',
+      source: "*",
       headers: [
         {
-          key: 'Content-Security-Policy',
-          value: 'frame-ancestors *;',
+          key: "Content-Security-Policy",
+          value: "frame-ancestors *;",
         },
       ],
     },
@@ -37,6 +37,9 @@ const config: GatsbyConfig = {
         apiHost: "https://eu.i.posthog.com",
         head: true,
         isEnabledDevMode: false,
+        initOptions: {
+          persistence: "memory",
+        },
       },
     },
     {
@@ -73,5 +76,4 @@ const config: GatsbyConfig = {
   ],
 };
 
-
-export default config
+export default config;

--- a/src/hooks/usePageView.js
+++ b/src/hooks/usePageView.js
@@ -14,6 +14,7 @@ export default function usePageViews(sitename) {
       // remove all previously assigned custom variables, requires Matomo (formerly Piwik) 3.0.2
       window._paq.push(["deleteCustomVariables", "page"]);
       window._paq.push(["setGenerationTimeMs", 0]);
+      window._paq.push(['disableCookies']);
       window._paq.push(["trackPageView"]);
 
       // make Matomo aware of newly added content

--- a/src/hooks/usePageView.js
+++ b/src/hooks/usePageView.js
@@ -14,7 +14,7 @@ export default function usePageViews(sitename) {
       // remove all previously assigned custom variables, requires Matomo (formerly Piwik) 3.0.2
       window._paq.push(["deleteCustomVariables", "page"]);
       window._paq.push(["setGenerationTimeMs", 0]);
-      window._paq.push(['disableCookies']);
+      window._paq.push(["disableCookies"]);
       window._paq.push(["trackPageView"]);
 
       // make Matomo aware of newly added content


### PR DESCRIPTION
Activation du mode cookieless pour Matomo et Posthog 
- https://posthog.com/tutorials/cookieless-tracking
- https://fr.matomo.org/faq/general/faq_157/ 

## Comment tester 

**Dépot de cookie :** 

1. Charger https://deploy-preview-138--quefairedemesdechets.netlify.app/dechet/smartphone/
2. Vérifier qu'aucun cookie n'est déposé


**Tracking :** 

1. Pour Matomo, je n'arrive pas à voir les stats dans Matomo...donc je suppose qu'on testera en prod. 
2. Pour Posthog : j'ai fait deux visites à une minute d'intervalle après fermeture du navigateur, on a bien des ID de `person` différents : [première visite](https://eu.posthog.com/project/23277/events/01919992-b396-7402-b504-b03f03a07ddd/2024-08-28T15%3A20%3A14.026000Zhttps://eu.posthog.com/project/23277/events/01919992-b396-7402-b504-b03f03a07ddd/2024-08-28T15%3A20%3A14.026000Z) et [deuxième visite](https://eu.posthog.com/project/23277/events/01919992-c368-7566-bde9-e434cb619e53/2024-08-28T15%3A20%3A18.106000Z) 