### PR TITLE
Prevent duplicate calls to Ocad3e

### DIFF
--- a/src/components/misc/MapWrapper.tsx
+++ b/src/components/misc/MapWrapper.tsx
@@ -63,8 +63,8 @@ const Loader = styled.div`
     height: 100%;
     background-color: ${(props) => props.theme.colors.second};
     transform: scaleX(0);
-    animation: ${({ $isFetching }) => ($isFetching ? fetching : "none")} 1s linear
-      infinite;
+    animation: ${({ $isFetching }) => ($isFetching ? fetching : "none")} 1s
+      linear infinite;
   }
 `;
 export default function MapWrapper(props) {
@@ -77,10 +77,13 @@ export default function MapWrapper(props) {
   });
   const [center, setCenter] = useState([47.5, 2]);
   const [zoom, setZoom] = useState(4.5);
-
   const [currentPlace, setCurrentPlace] = useState(null);
 
-  const { data, isFetching } = usePlaces(center, zoom, props.product);
+  const { data, isFetching } = usePlaces(
+    [address?.latitude, address?.longitude],
+    zoom,
+    props.product,
+  );
 
   const themeContext = useContext(ThemeContext);
 

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -109,9 +109,7 @@ export function usePosition(position) {
 }
 export function usePlaces(center, zoom, product) {
   const debouncedCenter = useDebounce(center);
-
-  const zoomedEnough = zoom > 10;
-
+  const enabled = !!(zoom > 10 && debouncedCenter?.[0] && debouncedCenter?.[1]);
   const {
     data: decheteries,
     isLoading: isLoadingDecheteries,
@@ -119,8 +117,8 @@ export function usePlaces(center, zoom, product) {
   } = useQuery({
     queryKey: ["decheteries", debouncedCenter],
     queryFn: fetchDecheteries,
-    enabled: product["Bdd"] === "sinoe" && zoomedEnough ? true : false,
-    keepPreviousData: product["Bdd"] === "sinoe" && zoomedEnough ? true : false,
+    enabled: product["Bdd"] === "sinoe" && enabled,
+    keepPreviousData: product["Bdd"] === "sinoe" && enabled,
   });
 
   const {
@@ -130,9 +128,8 @@ export function usePlaces(center, zoom, product) {
   } = useQuery({
     queryKey: ["pvsoren", debouncedCenter],
     queryFn: fetchPvsoren,
-    enabled: product["Code"] === "ADEME_SOLAIRE" && zoomedEnough ? true : false,
-    keepPreviousData:
-      product["Code"] === "ADEME_SOLAIRE" && zoomedEnough ? true : false,
+    enabled: product["Code"] === "ADEME_SOLAIRE" && enabled,
+    keepPreviousData: product["Code"] === "ADEME_SOLAIRE" && enabled,
   });
 
   const {
@@ -144,14 +141,10 @@ export function usePlaces(center, zoom, product) {
     queryFn: fetchPharmacies,
     enabled:
       (product["Bdd"] === "google" || product["Code"] === "ADEME_DASRI") &&
-      zoomedEnough
-        ? true
-        : false,
+      enabled,
     keepPreviousData:
       (product["Bdd"] === "google" || product["Code"] === "ADEME_DASRI") &&
-      zoomedEnough
-        ? true
-        : false,
+      enabled,
   });
 
   const {
@@ -161,9 +154,8 @@ export function usePlaces(center, zoom, product) {
   } = useQuery({
     queryKey: ["ocad3e", debouncedCenter, product["Code"]],
     queryFn: fetchOcad3e,
-    enabled: product["Bdd"] === "ocad3e" && zoomedEnough ? true : false,
-    keepPreviousData:
-      product["Bdd"] === "ocad3e" && zoomedEnough ? true : false,
+    enabled: product["Bdd"] === "ocad3e" && enabled,
+    keepPreviousData: product["Bdd"] === "ocad3e" && enabled,
   });
 
   return {
@@ -193,19 +185,19 @@ const fetchDecheteries = ({ queryKey }) =>
       queryKey[1][0]
     }%2C${15000}&size=1000&sampling=neighbors&select=ANNEE%2CN_SERVICE%2CAD1_SITE%2CCP_SITE%2CL_VILLE_SITE%2C_geopoint%2C_id`,
   )
-  .then((res) => res.json())
-  .then((res) =>
-    res.results.map((place) => ({
-      id: place["_id"],
-      latitude: Number(place["_geopoint"].split(",")[0]),
-      longitude: Number(place["_geopoint"].split(",")[1]),
-      title: place["N_SERVICE"].replaceAll(" ", " "),
-      address: `${place["AD1_SITE"].replaceAll(" ", " ")}
+    .then((res) => res.json())
+    .then((res) =>
+      res.results.map((place) => ({
+        id: place["_id"],
+        latitude: Number(place["_geopoint"].split(",")[0]),
+        longitude: Number(place["_geopoint"].split(",")[1]),
+        title: place["N_SERVICE"].replaceAll(" ", " "),
+        address: `${place["AD1_SITE"].replaceAll(" ", " ")}
                       <br />
                       ${place["CP_SITE"]}
                       ${place["L_VILLE_SITE"].replaceAll(" ", " ")}`,
-    })),
-  );
+      })),
+    );
 const fetchPvsoren = ({ queryKey }) =>
   fetch(
     `https://data.pointsapport.ademe.fr/data-fair/api/v1/datasets/donnees-de-geolocalisation-des-points-dapport-pv-soren/lines?format=json&q_mode=simple&geo_distance=${

--- a/src/views/product/details/Map.js
+++ b/src/views/product/details/Map.js
@@ -1,7 +1,7 @@
 import React, { useRef } from "react";
 import styled from "styled-components";
 
-import MapWrapper from "components/misc/MapWrapper";
+import LegacyMapWrapper from "components/misc/MapWrapper";
 
 const Wrapper = styled.div`
   position: relative;
@@ -16,7 +16,7 @@ const IFrame = styled.iframe`
   height: 100%;
 `;
 
-const IFrameWrapper = ({ src }) => {
+const MapWrapper = ({ src }) => {
   const iframeRef = useRef(null);
 
   function handleLoad() {
@@ -42,9 +42,9 @@ export default function Map({ lvaoData, product }) {
   return (
     <Wrapper $LVAOMapIsDisplayed={!!lvaoData?.url_carte}>
       {lvaoData?.url_carte ? (
-        <IFrameWrapper src={lvaoData.url_carte} />
+        <MapWrapper src={lvaoData.url_carte} />
       ) : (
-        <MapWrapper product={product} />
+        <LegacyMapWrapper product={product} />
       )}
     </Wrapper>
   );

--- a/src/views/product/details/Map.js
+++ b/src/views/product/details/Map.js
@@ -16,7 +16,7 @@ const IFrame = styled.iframe`
   height: 100%;
 `;
 
-const MapWrapper = ({ src }) => {
+const LVAOMapWrapper = ({ src }) => {
   const iframeRef = useRef(null);
 
   function handleLoad() {

--- a/src/views/product/details/Map.js
+++ b/src/views/product/details/Map.js
@@ -42,7 +42,7 @@ export default function Map({ lvaoData, product }) {
   return (
     <Wrapper $LVAOMapIsDisplayed={!!lvaoData?.url_carte}>
       {lvaoData?.url_carte ? (
-        <MapWrapper src={lvaoData.url_carte} />
+        <LVAOMapWrapper src={lvaoData.url_carte} />
       ) : (
         <LegacyMapWrapper product={product} />
       )}


### PR DESCRIPTION
Ref : https://www.notion.so/accelerateur-transition-ecologique-ademe/Regression-de-la-carte-legacy-sur-QFDMOD-0da40e805cec4925ba6dee5cb2f1d52f?pvs=4

La carte fait deux appels à Ocad3e lorsque l'utilisateur choisit une adresse. 
- un premier appel avec le centre de la France
- un deuxième appel avec la latitude / longitude correspondant à son adresse

Ici on modifie l'appel pour qu'il n'ait lieu qu'après que la latitude / longitude de l'adresse choisit par l'utilisateur soit définie. 

En bonus 
- Remplacement du composant par son équivalent typescript
- extraction dans une variable `enabled` de la condition d'activation des appels API (on pourrait faire mieux...mais ça reste du legacy 😬)
- Renommage localement (dans le composant Details) de l'ancienne carte en `LegacyMapWrapper` et la nouvelle en `MapWrapper`

### Comment tester 

1. Aller sur `/dechet/smartphone/` 
2. Ouvrir la console réseau
3. Entrer une adresse (loin du centre de la France idéalement, `Rennes` par exemple
4. Vérifier qu'un seul appel à Ocad3e est effectué
5. Vérifier que des résultats s'affichent sur la carte 