### PR TITLE
Prevent multiple renders when geolocate user

### DIFF
--- a/src/components/misc/MapWrapper.tsx
+++ b/src/components/misc/MapWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from "react";
+import React, { useState, useContext, useEffect } from "react";
 import styled, { keyframes, ThemeContext } from "styled-components";
 import { Map, Marker, Overlay, ZoomControl } from "pigeon-maps";
 
@@ -63,13 +63,12 @@ const Loader = styled.div`
     height: 100%;
     background-color: ${(props) => props.theme.colors.second};
     transform: scaleX(0);
-    animation: ${({ $isFetching }) => ($isFetching ? fetching : "none")} 1s linear
-      infinite;
+    animation: ${({ $isFetching }) => ($isFetching ? fetching: "none")} 1s
+      linear infinite;
   }
 `;
 export default function MapWrapper(props) {
   const [list, setList] = useState(false);
-
   const [address, setAddress] = useState({
     label: "",
     longitude: null,
@@ -77,29 +76,32 @@ export default function MapWrapper(props) {
   });
   const [center, setCenter] = useState([47.5, 2]);
   const [zoom, setZoom] = useState(4.5);
-
   const [currentPlace, setCurrentPlace] = useState(null);
-
   const { data, isFetching } = usePlaces(center, zoom, props.product);
 
   const themeContext = useContext(ThemeContext);
+
+  useEffect(() => {
+    if (address.latitude && address.longitude) {
+      window._paq?.push(["trackEvent", "Map", "Adresse"]);
+    }
+  }, [address]);
+  useEffect(() => {
+    if (list) {
+      window._paq?.push(["trackEvent", "Map", "List"]);
+    }
+  }, [list]);
 
   return (
     <>
       <Address
         address={address.label}
-        setAddress={(value) => {
-          window._paq?.push(["trackEvent", "Map", "Adresse"]);
-          setAddress(value);
-        }}
+        setAddress={setAddress}
         setCenter={setCenter}
         setZoom={setZoom}
       />
       <Switch
-        setList={(value) => {
-          window._paq?.push(["trackEvent", "Map", "List"]);
-          setList(value);
-        }}
+        setList={setList}
         list={list}
       />
       <Loader $isFetching={isFetching} />

--- a/src/components/misc/mapWrapper/Address.tsx
+++ b/src/components/misc/mapWrapper/Address.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import styled from "styled-components";
 
 import { useSearch } from "utils/api";
@@ -24,17 +24,13 @@ const Wrapper = styled.form`
   //overflow: hidden;
 
   ${(props) => props.theme.mq.small} {
-    top: ${({ $addressSet}) => ($addressSet ? "2.5rem" : "5rem")};
+    top: ${({ $addressSet }) => ($addressSet ? "2.5rem" : "5rem")};
   }
 `;
 
-export default function Address(props) {
+export default function Address({ setAddress, setCenter, setZoom, address }) {
   const [search, setSearch] = useState("");
-  useEffect(() => {
-    setSearch(props.address);
-  }, [props.address]);
   const debouncedSearch = useDebounce(search);
-
   const { data, isFetching } = useSearch(debouncedSearch);
 
   const [focus, setFocus] = useState(false);
@@ -48,26 +44,33 @@ export default function Address(props) {
     }
   }, [focus]);
 
-  const navigateToPlace = (place) => {
-    if (place) {
-      props.setAddress({
-        label: place.properties.label,
-        latitude: place.geometry.coordinates[1],
-        longitude: place.geometry.coordinates[0],
-      });
-      props.setCenter([
-        place.geometry.coordinates[1],
-        place.geometry.coordinates[0],
-      ]);
-      props.setZoom(13);
-      setFocus(false);
-    }
-  };
+  const navigateToPlace = useCallback(
+    (place) => {
+      if (place) {
+        setAddress({
+          label: place.properties.label,
+          latitude: place.geometry.coordinates[1],
+          longitude: place.geometry.coordinates[0],
+        });
+        setCenter([
+          place.geometry.coordinates[1],
+          place.geometry.coordinates[0],
+        ]);
+        setZoom(13);
+        setFocus(false);
+      }
+    },
+    [setCenter, setZoom, setFocus, setAddress],
+  );
+
+  useEffect(() => {
+    setSearch(address);
+  }, [address]);
 
   return (
     <Wrapper
       $focus={focus}
-      $addressSet={props.address}
+      $addressSet={address}
       onSubmit={(e) => {
         e.preventDefault();
         if (current > -1) {

--- a/src/components/misc/mapWrapper/address/TextInput.tsx
+++ b/src/components/misc/mapWrapper/address/TextInput.tsx
@@ -26,25 +26,36 @@ const Input = styled.input`
     outline: none;
   }
 `;
-export default React.forwardRef(function TextInput(props, ref) {
+export default React.forwardRef(function TextInput(
+  {
+    setFocus,
+    setSearch,
+    search,
+    suggestion,
+    suggestionVisible,
+    navigateToPlace,
+  },
+  ref,
+) {
+
   return (
     <Wrapper>
       <Input
         ref={ref}
         type="text"
         placeholder="Entrez votre adresse"
-        value={props.search}
-        onChange={(e) => props.setSearch(e.target.value)}
-        onFocus={() => props.setFocus(true)}
-        onBlur={() => props.setFocus(false)}
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        onFocus={() => setFocus(true)}
+        onBlur={() => setFocus(false)}
       />
       <Submit
-        visible={props.suggestion && props.suggestionVisible && props.search}
-        setFocus={props.setFocus}
+        visible={suggestion && suggestionVisible && search}
+        setFocus={setFocus}
       />
       <Geoloc
-        visible={!(props.suggestion && props.suggestionVisible && props.search)}
-        navigateToPlace={props.navigateToPlace}
+        visible={!(suggestion && suggestionVisible && search)}
+        navigateToPlace={navigateToPlace}
       />
     </Wrapper>
   );

--- a/src/components/misc/mapWrapper/address/textInput/Geoloc.tsx
+++ b/src/components/misc/mapWrapper/address/textInput/Geoloc.tsx
@@ -65,7 +65,7 @@ const Error = styled.div`
     }
   }
 `;
-export default function Geoloc(props) {
+export default function Geoloc({ navigateToPlace, visible }) {
   const [position, setPosition] = useState(null);
 
   const [isGeolocating, setIsGeolocating] = useState(null);
@@ -73,8 +73,8 @@ export default function Geoloc(props) {
   const { data, isFetching, isError } = usePosition(position);
 
   useEffect(() => {
-    data && data.features && props.navigateToPlace(data.features[0]);
-  }, [data, props]);
+    data && data.features && navigateToPlace(data.features[0]);
+  }, [data, navigateToPlace]);
 
   const [error, setError] = useState(false);
 
@@ -83,7 +83,7 @@ export default function Geoloc(props) {
     "geolocation" in navigator ? (
     <>
       <Wrapper
-        $visible={props.visible && !error && !isError}
+        $visible={visible && !error && !isError}
         $fetching={isFetching || isGeolocating}
         type="button"
         onClick={() => {


### PR DESCRIPTION
Ref : https://www.notion.so/accelerateur-transition-ecologique-ademe/Regression-de-la-carte-legacy-sur-QFDMOD-0da40e805cec4925ba6dee5cb2f1d52f?pvs=4

On a des re-renders intempestifs dûs à des changements récents : 
- J'ai passé `props` comme dépendance d'un `useEffect` un peu bêtement, j'ai donc séparé les props en question pour ne passer que le prop `navigateToPlace` qui était la cause du re-render 
- J'ai wrappé cette fonction d'un `useCallback`, c'est un pansement, si on voulait faire vraiment propre on aurait pu écrire un hook, mais ça a le mérite de fonctionner sans revoir en profondeur le composant 


**En bonus**
- J'ai renommé plusieurs composants sur lesquels j'ai travaillé en .tsx, j'ai conservé ce changement 
- J'ai extrait les appels à matomo dans des hooks d'effet pour rendre plus explicite ces appels 
- J'ai abaissé un `useEffect` qui était un peu haut dans le composant

### Comment tester 

Il est idéal d'avoir le debugger react pour tester 
- https://chromewebstore.google.com/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi
- https://addons.mozilla.org/en-US/firefox/addon/react-devtools/

Activer l'enregistrement de la raison d'un rendering dans les paramètres de l'extension (inspecter > onglet composants > cocher la case ci-dessous)
![image](https://github.com/user-attachments/assets/8fe40890-2dcb-4030-8f6e-2421d7590fa8)

1. Aller sur `/dechet/smartphone`
2. Ouvrir le profiler réactif 
3. Cliquer sur **Start profiling** en haut à gauche
4. Cliquer sur le bouton de géolocalisation dans le site quefairedemesdechets
5. Arrêter le profiling après quelques secondes 

Tout en bas du profiling se trouve le composant `Geoloc`, en le sélectionnant on peut voir le nombre de renderings 
![image](https://github.com/user-attachments/assets/7e2eac79-817c-45c8-815f-e6861126df2f)

Ceux-ci doivent se situer autour de 8-10, s'il y en a plus (des dizaines notamment), c'est qu'il y a un soucis 😬 