### PR TITLE
Correction du lien Partager > Copier dans le presse papier dans l'iframe LVAO de QFDMOD

### DIFF
--- a/src/views/product/details/Map.js
+++ b/src/views/product/details/Map.js
@@ -26,7 +26,7 @@ const LVAOMapWrapper = ({ src }) => {
   return (
     <IFrame
       id="lvao_iframe"
-      allow="geolocation"
+      allow="geolocation; clipboard-write"
       allowFullScreen={true}
       webkitallowfullscreen="true"
       mozallowfullscreen="true"


### PR DESCRIPTION
Notion : [Réparer le bouton “Copier le lien” (dans “Partager”) dans l’iframe dédié à QFDMD](https://www.notion.so/accelerateur-transition-ecologique-ademe/R-parer-le-bouton-Copier-le-lien-dans-Partager-dans-l-iframe-d-di-QFDMD-1066523d57d7803aa02adc43044cec97?pvs=4)

Correction du lien `Partager` > `Copier dans le presse papier` dans l'iframe LVAO de QFDMOD

